### PR TITLE
Fixing CommonJS/ES6 Hybrid Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "lipe",
 	"version": "0.2.0",
 	"description": "A Logging library with full customizability",
-	"typings": "lib/types",
+	"typings": "lib/Types",
 	"packageManager": "pnpm@6.32.2",
 	"exports": {
 		".": {
@@ -18,7 +18,6 @@
 		"test": "jest",
 		"test:script": "node --es-module-specifier-resolution=node ./tests/test.js",
 		"build": "node ./util/CompileProject.mjs",
-		"buildOld": "tsc -p tsconfig.json",
 		"watch": "tsc -w -p tsconfig.json",
 		"postinstall": "node ./util/PostInstall.mjs",
 		"prepublish": "pnpm run build"

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,7 +1,7 @@
-export { Colorize } from "./transforms/colors";
-export { SimplePrefix, PrefixWithColor } from "./transforms/prefix";
-export { Splat } from "./transforms/splat";
-export { Timestamped } from "./transforms/time";
+export { Colorize } from "./transforms/colors.js";
+export { SimplePrefix, PrefixWithColor } from "./transforms/prefix.js";
+export { Splat } from "./transforms/splat.js";
+export { Timestamped } from "./transforms/time.js";
 
-export { Console } from "./outputs/console";
-export { WriteToFile } from "./outputs/file";
+export { Console } from "./outputs/console.js";
+export { WriteToFile } from "./outputs/file.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { InternalSplat } from "./utils/util";
+import { InternalSplat } from "./utils/util.js";
 
 // export * as Defaults from "./defaults";
 

--- a/src/outputs/console.ts
+++ b/src/outputs/console.ts
@@ -1,4 +1,4 @@
-import { IFormatter, LogLevel } from "..";
+import { IFormatter, LogLevel } from "../index.js";
 
 export const Console: () => IFormatter = () => (message, { logLevel }) => {
 	// Bitwise checks to filter for Critical and Error messages

--- a/src/outputs/file.ts
+++ b/src/outputs/file.ts
@@ -1,4 +1,4 @@
-import { IFormatter, LogLevel } from "..";
+import { IFormatter, LogLevel } from "../index.js";
 import { existsSync, appendFileSync, writeFileSync } from "fs";
 import { join } from "path";
 

--- a/src/transforms/prefix.ts
+++ b/src/transforms/prefix.ts
@@ -1,5 +1,5 @@
 import chalk, { ChalkFunction } from "chalk";
-import { IFormatter, LogLevel } from "../index";
+import { IFormatter, LogLevel } from "../index.js";
 
 const LogColors: { [key: number]: ChalkFunction } = {
 	[LogLevel.Debug]: chalk.blueBright.bold,

--- a/src/transforms/splat.ts
+++ b/src/transforms/splat.ts
@@ -1,5 +1,5 @@
 import { IFormatter } from "..";
-import { InternalSplat } from "../utils/util";
+import { InternalSplat } from "../utils/util.js";
 
 export const Splat: (format: string) => IFormatter = (
 	format: string = "{Message}"

--- a/src/transforms/time.ts
+++ b/src/transforms/time.ts
@@ -1,4 +1,4 @@
-import { IFormatter } from "..";
+import { IFormatter } from "../index.js";
 import moment from "moment";
 
 export function Timestamped(format: string): IFormatter;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"allowJs": true,
 		"esModuleInterop": true,
 		"declaration": true,
-		"declarationDir": "lib/types",
+		"declarationDir": "lib/Types",
 		"sourceMap": true,
 		"sourceRoot": "/src",
 		"outDir": "lib"

--- a/util/CompileProject.mjs
+++ b/util/CompileProject.mjs
@@ -138,6 +138,25 @@ export function Compile() {
 					if (IsMainModule) process.exit(1);
 					else return res(false);
 				}
+
+				let pack = {
+					type: null
+				};
+
+				switch(module)
+				{
+					case "CommonJS":
+						pack.type = "commonjs"
+						break;
+					case "ES6":
+						pack.type = "module"
+					break;
+					default: 
+						console.warn("No package.json type for Non Standard Module " + module);
+				}
+
+				fs.writeFileSync(`./lib/${module}/package.json`, JSON.stringify(pack));
+				
 			}
 			return res(true);
 		});


### PR DESCRIPTION
I was doing more reading into creating a single package that does both CommonJS as well as ES6 and came across [this](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html) article that outlines experiences with the subject. In it is mentioned that to get it to work the author had to have a separate package.json per Module type in the dist folder so it would pick up on the JS files properly.