### PR TITLE
Appending rest of current pipe onto the end of any pipe returned

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,14 +103,13 @@ export class LoggerPipe {
 		args = {},
 		options,
 	}: IPipeData) {
-		let result = undefined;
 		for (let i = 0; i < this.pipe.length; ++i) {
 			const func = this.pipe[i];
-
+			
 			// Skip any non Function that made its way into the pipe
 			if (!func && typeof func !== "function") continue;
-
-			result = func(message, {
+			
+			let result = func(message, {
 				args: { ...args },
 				logLevel: logLevel,
 				meta,
@@ -133,8 +132,11 @@ export class LoggerPipe {
 
 			// If the resulting object is a LoggerPipe we pass it through.
 			if (result && result instanceof LoggerPipe) {
+				
+				if(i + 1 < this.pipe.length)
+					result = result.Pipe(...this.pipe.slice(i + 1));
+			
 				const pipeResult = result
-					.Pipe(...this.pipe.slice(i + 1))
 					.Execute({
 						[MessageSymbol]: message,
 						[LogLevelSymbol]: logLevel,
@@ -143,6 +145,7 @@ export class LoggerPipe {
 						options: options,
 					})
 					.catch(console.error);
+
 
 				// This is still up in the air. It will wait until all of the pipe has finished executing
 				if (options.awaitPromises) await pipeResult;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -136,6 +136,21 @@ describe("Transform Messages", () => {
 		expect(output).toBeCalledWith(message, expect.objectContaining({logLevel: LogLevel.Log}));
 	});
 
+	test("Seperate Pipe can Transform message", () => {
+		logger = new Logger();
+
+		logger.pipe
+			.Pipe(() => new LoggerPipe([(msg) => "Piped:" + msg]))
+			.Pipe(output);
+
+		logger.Log(message);
+
+		expect(output).toBeCalledWith(
+			"Piped:" + message,
+			expect.objectContaining({ logLevel: LogLevel.Log })
+		);
+	});
+
 
 });
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -60,3 +60,15 @@ logger.Critical("Here is a Critical Application Problem");
 let childLogger = logger.Child();
 
 childLogger.Info("A log from a Child Logger");
+
+logger.Child({isSecret: true}).Info("A hidden log due to the childlogger being secret.");
+
+logger.ClearPipes();
+
+const pipeA = new LoggerPipe([(msg) => "foo " + msg]);
+const pipeB = new LoggerPipe([(msg) => "bar " + msg]);
+
+logger.pipe.Pipe((msg) => msg.includes("fighters") ? pipeA : pipeB).Pipe(Console());
+
+logger.Log("fighters");
+logger.Log("bashers");


### PR DESCRIPTION
With this functionality its now possible to have a pipe transform data that then gets passed into another pipe. e.g:
```typescript
import Logger, {LoggerPipe} from "lipe";
import { Console } from "lipe/defaults";

const pipeA = new LoggerPipe([(msg) => "A:" + msg])
const pipeB = new LoggerPipe([(msg) => "B:" + msg])

const logger = new Logger();
logger.pipe.Pipe((msg, ctx) => ctx.args.Logger == "A" ? pipeA : pipeB);

logger.Log("Log", {logger: "A"}) // A:Log
logger.Log("Log", {logger: "B"}) // B:Log
```
In the previous version the pipes were essentially branching pathways so there was no way to retrieve the data evaluated however because the Pipes are immutable & composable we can now just append the remaining tasks from the current pipe onto the end of the returned Pipe and any transformations that the returned pipe will cause will be passed onto the remainig elements.